### PR TITLE
Hi, cl-oauth was no longer working with drakma because of change put in a few months ago. As per various

### DIFF
--- a/src/core/consumer.lisp
+++ b/src/core/consumer.lisp
@@ -20,25 +20,26 @@ it has query params already they are added onto it."
 
 (defun http-request (uri &key (request-method :get) parameters drakma-args)
   ;; TODO handle redirects properly
-  (let* ((param-string-encoded (alist->query-string parameters :include-leading-ampersand nil :url-encode t)))
-    (case request-method
-      (:get 
-        (apply #'drakma:http-request
-	       (uri-with-additional-query-part uri param-string-encoded)
-               :method request-method
-               drakma-args))
-      (:post
-        (apply #'drakma:http-request
-               uri
-               :method request-method
-               :content param-string-encoded
-               drakma-args))
-      (:auth
-        (apply #'drakma:http-request
-               uri
-               :method :get
-               :additional-headers `(("Authorization" . ,(build-auth-string parameters)))
-               drakma-args)))))
+  (case request-method
+    (:get 
+     (apply #'drakma:http-request 
+	    uri
+	    :parameters parameters
+	    :method request-method
+	    drakma-args))
+    (:post
+     (apply #'drakma:http-request
+	    uri
+	    :method request-method
+	    :parameters parameters
+	    ;;:content param-string-encoded
+	    drakma-args))
+    (:auth
+     (apply #'drakma:http-request
+	    uri
+	    :method :get
+	    :additional-headers `(("Authorization" . ,(build-auth-string parameters)))
+	    drakma-args))))
 
 (defun obtain-request-token (uri consumer-token
                              &key (version :1.0) user-parameters drakma-args


### PR DESCRIPTION
Parameters were encoded and aded on to the uri. This caused drakma to
encode this twice for the get commands..
Using :parameters seems cleaner
