### PR TITLE
Separate tests into their own system.

### DIFF
--- a/cl-oauth.asd
+++ b/cl-oauth.asd
@@ -41,26 +41,29 @@
                                                            (:file "service-provider"
                                                                   :depends-on ("tokens" "parameters"
                                                                                "error-handling")))
-                                              :depends-on ("package" "util"))))
-               (:module "test"
-                        :components ((:file "package")
-                                     (:module "core"
-                                              :components ((:file "request-adapter")
-                                                           (:file "parameters"
-                                                                  :depends-on ("request-adapter"))
-                                                           (:file "signature"
-                                                                  :depends-on ("request-adapter"))
-                                                           (:file "tokens")
-                                                           (:file "service-provider"
-                                                                  :depends-on ("request-adapter")))
-                                              :depends-on ("package")))
-                        :depends-on ("src")))
+                                              :depends-on ("package" "util")))))
   :depends-on (:ironclad :cl-base64 :babel
                :closer-mop
                :alexandria :anaphora :f-underscore :split-sequence
                :trivial-garbage
-               :fiveam
                :drakma
                :puri :hunchentoot)
-  :in-order-to ((asdf:test-op (load-op "cl-oauth"))))
+  :in-order-to ((test-op (load-op cl-oauth.tests))))
 
+(defmethod operation-done-p ((op test-op) (c (eql (find-system :cl-oauth))))
+  (values nil))
+
+(defsystem :cl-oauth.tests
+  :depends-on (:fiveam :cl-oauth)
+  :pathname "test/"
+  :components ((:file "package")
+               (:module "core"
+                        :components ((:file "request-adapter")
+                                     (:file "parameters"
+                                            :depends-on ("request-adapter"))
+                                     (:file "signature"
+                                            :depends-on ("request-adapter"))
+                                     (:file "tokens")
+                                     (:file "service-provider"
+                                            :depends-on ("request-adapter")))
+                        :depends-on ("package"))))


### PR DESCRIPTION
This removes the dependency on fiveam from the primary system and means we don't load the tests if we're not using them.

This does NOT change how tests are run. `(asdf:test-system :cl-oauth)` still works.
