### PR TITLE
drakma:http-request no longer has a :redirect-methods argument

### DIFF
--- a/src/core/consumer.lisp
+++ b/src/core/consumer.lisp
@@ -30,7 +30,6 @@ it has query params already they are added onto it."
                                  (cons `("Authorization" . ,(build-auth-string auth-parameters))
                                        additional-headers)
                                  additional-headers)
-         :redirect-methods '(:get :post :head)
          drakma-args))
 
 (defun generate-auth-parameters


### PR DESCRIPTION
The patch removes the :redirect-methods argument in the call to drakma:http-request from oath::http-request to prevent an error being raised for using an incorrect keyword argument.

I don't know if anything needs to be added to achieve what that line was previously doing.
