### PR TITLE
Adapt to current DRAKMA release

### DIFF
--- a/src/core/consumer.lisp
+++ b/src/core/consumer.lisp
@@ -30,7 +30,6 @@ it has query params already they are added onto it."
                                  (cons `("Authorization" . ,(build-auth-string auth-parameters))
                                        additional-headers)
                                  additional-headers)
-         :redirect-methods '(:get :post :head)
          drakma-args))
 
 (defun generate-auth-parameters


### PR DESCRIPTION
The :redirect-methods keyword argument has been removed from drakma:http-request.  This patch fixes :cl-oauth accordingly.  Thanks!
