### PR TITLE
Added PARAMETERS option to HTTP-REQUEST in ACCESS-PROTECTED-RESOURCE

### DIFF
--- a/src/core/consumer.lisp
+++ b/src/core/consumer.lisp
@@ -306,6 +306,7 @@ whenever the access token is renewed."
                         :method request-method
                         :auth-location auth-location
                         :auth-parameters signed-parameters
+                        :parameters user-parameters
                         :additional-headers additional-headers
                         :drakma-args drakma-args)
         (if (eql status 200)


### PR DESCRIPTION
USER-PARAMETERS in ACCESS-PROTECTED-RESOURCE function seems to be ignored. 
